### PR TITLE
Implement reboot boot sequence

### DIFF
--- a/assets/terminal.css
+++ b/assets/terminal.css
@@ -177,15 +177,17 @@ input, textarea, select {
 
 .boot-sequence {
     margin-bottom: 20px;
-    max-height: 300px;
+    max-height: none;
+    min-height: 70vh;
     overflow-y: auto;
     padding: 10px;
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(0, 0, 0, 0.9);
     font-family: 'JetBrains Mono', monospace;
     font-size: 12px;
     line-height: 1.3;
     border: none;
     outline: none;
+    cursor: pointer; /* Allow click to skip */
 }
 
 .boot-line {


### PR DESCRIPTION
## Summary
- play boot sequence only once per visit
- allow skipping boot with click or ESC
- reboot command clears screen and reruns boot
- enlarge boot sequence container for full-screen view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68862115dee8832a99f2fbff411d68db